### PR TITLE
Runtime error handling

### DIFF
--- a/core/api/src/main/kotlin/org/merideum/core/api/InterpreterExtensions.kt
+++ b/core/api/src/main/kotlin/org/merideum/core/api/InterpreterExtensions.kt
@@ -1,4 +1,4 @@
-package org.merideum.core.api.executor
+package org.merideum.core.api
 
 import org.merideum.core.interpreter.Modifier
 import org.merideum.core.interpreter.VariableScope

--- a/core/api/src/main/kotlin/org/merideum/core/api/MerideumResourceResolver.kt
+++ b/core/api/src/main/kotlin/org/merideum/core/api/MerideumResourceResolver.kt
@@ -1,4 +1,4 @@
-package org.merideum.core.api.executor
+package org.merideum.core.api
 
 import org.merideum.core.interpreter.Resource
 import org.merideum.core.interpreter.ResourceResolver

--- a/core/api/src/main/kotlin/org/merideum/core/api/Request.kt
+++ b/core/api/src/main/kotlin/org/merideum/core/api/Request.kt
@@ -1,10 +1,10 @@
-package org.merideum.core.api.executor
+package org.merideum.core.api
 
 import org.merideum.core.interpreter.ScriptContext
 import org.merideum.core.interpreter.Resource
 import org.merideum.core.interpreter.error.FunctionNotFoundException
 import org.merideum.core.interpreter.type.TypedValue
-import org.merideum.core.api.executor.error.RequestFailException
+import org.merideum.core.api.error.RequestFailException
 
 /**
  * A variable that is injected into a script to represent the http request context.

--- a/core/api/src/main/kotlin/org/merideum/core/api/SimpleScriptExecutor.kt
+++ b/core/api/src/main/kotlin/org/merideum/core/api/SimpleScriptExecutor.kt
@@ -43,7 +43,7 @@ class SimpleScriptExecutor(val resourceResolver: ResourceResolver): ScriptExecut
     } catch(rt: ReturnTermination) {
       ScriptExecutionResult(rt.value)
     } catch(e: ScriptRuntimeException) {
-      ScriptExecutionResult(null, ErrorsContainer(e.message))
+      ScriptExecutionResult(null, ErrorsContainer(e))
     }
   }
 }

--- a/core/api/src/main/kotlin/org/merideum/core/api/SimpleScriptExecutor.kt
+++ b/core/api/src/main/kotlin/org/merideum/core/api/SimpleScriptExecutor.kt
@@ -1,16 +1,18 @@
-package org.merideum.core.api.executor
+package org.merideum.core.api
 
 import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.tree.ParseTree
 import org.merideum.antlr.MerideumLexer
 import org.merideum.antlr.MerideumParser
+import org.merideum.core.api.error.ErrorsContainer
+import org.merideum.core.api.execution.ScriptExecutionResult
+import org.merideum.core.api.execution.ScriptExecutor
 import org.merideum.core.interpreter.ResourceResolver
 import org.merideum.core.interpreter.ReturnTermination
 import org.merideum.core.interpreter.ScriptContext
 import org.merideum.core.interpreter.VariableScope
-import org.merideum.core.interpreter.execution.ScriptExecutionResult
-import org.merideum.core.interpreter.execution.ScriptExecutor
+import org.merideum.core.interpreter.error.ScriptRuntimeException
 import org.merideum.core.interpreter.visitors.ScriptVisitor
 
 class SimpleScriptExecutor(val resourceResolver: ResourceResolver): ScriptExecutor {
@@ -34,15 +36,14 @@ class SimpleScriptExecutor(val resourceResolver: ResourceResolver): ScriptExecut
 
     val visitor = ScriptVisitor(mainScope, resourceResolver, context)
 
-    val returnValue: Map<String, Any?>? = try {
+    return try {
       visitor.visit(parseTree)
 
-      null
+      ScriptExecutionResult(null)
     } catch(rt: ReturnTermination) {
-      rt.value
+      ScriptExecutionResult(rt.value)
+    } catch(e: ScriptRuntimeException) {
+      ScriptExecutionResult(null, ErrorsContainer(e.message))
     }
-
-
-    return ScriptExecutionResult(returnValue)
   }
 }

--- a/core/api/src/main/kotlin/org/merideum/core/api/error/ErrorsContainer.kt
+++ b/core/api/src/main/kotlin/org/merideum/core/api/error/ErrorsContainer.kt
@@ -1,0 +1,11 @@
+package org.merideum.core.api.error
+
+data class ErrorsContainer(
+  val runtime: String?
+) {
+  fun toMap() = buildMap<String, Any> {
+    if (runtime != null) {
+      this["runtime"] = runtime
+    }
+  }
+}

--- a/core/api/src/main/kotlin/org/merideum/core/api/error/ErrorsContainer.kt
+++ b/core/api/src/main/kotlin/org/merideum/core/api/error/ErrorsContainer.kt
@@ -1,11 +1,16 @@
 package org.merideum.core.api.error
 
+import org.merideum.core.interpreter.error.ScriptRuntimeException
+
 data class ErrorsContainer(
-  val runtime: String?
+  val runtime: ScriptRuntimeException?
 ) {
   fun toMap() = buildMap<String, Any> {
     if (runtime != null) {
-      this["runtime"] = runtime
+      this["runtime"] = buildMap<String, Any> {
+        this["type"] = runtime.type.name
+        this["message"] = runtime.message
+      }
     }
   }
 }

--- a/core/api/src/main/kotlin/org/merideum/core/api/error/RequestFailException.kt
+++ b/core/api/src/main/kotlin/org/merideum/core/api/error/RequestFailException.kt
@@ -1,3 +1,3 @@
-package org.merideum.core.api.executor.error
+package org.merideum.core.api.error
 
 class RequestFailException: RuntimeException()

--- a/core/api/src/main/kotlin/org/merideum/core/api/execution/ScriptExecutionResult.kt
+++ b/core/api/src/main/kotlin/org/merideum/core/api/execution/ScriptExecutionResult.kt
@@ -1,0 +1,19 @@
+package org.merideum.core.api.execution
+
+import org.merideum.core.api.error.ErrorsContainer
+
+/**
+ * The result of a Merideum script run.
+ */
+data class ScriptExecutionResult(
+  val output: Map<String, Any?>?,
+  val errors: ErrorsContainer? = null
+) {
+  fun toResponse() = buildMap {
+    this["output"] = output
+
+    if (errors != null) {
+      this["errors"] = errors.toMap()
+    }
+  }
+}

--- a/core/api/src/main/kotlin/org/merideum/core/api/execution/ScriptExecutor.kt
+++ b/core/api/src/main/kotlin/org/merideum/core/api/execution/ScriptExecutor.kt
@@ -1,4 +1,4 @@
-package org.merideum.core.interpreter.execution
+package org.merideum.core.api.execution
 
 import org.merideum.core.interpreter.ScriptContext
 

--- a/core/api/src/main/kotlin/org/merideum/core/api/serializer/ObjectSerializer.kt
+++ b/core/api/src/main/kotlin/org/merideum/core/api/serializer/ObjectSerializer.kt
@@ -1,4 +1,4 @@
-package org.merideum.core.api.executor.serializer
+package org.merideum.core.api.serializer
 
 import org.merideum.core.interpreter.type.MerideumObject
 

--- a/core/api/src/test/kotlin/org/merideum/core/api/MerideumResourceResolverTests.kt
+++ b/core/api/src/test/kotlin/org/merideum/core/api/MerideumResourceResolverTests.kt
@@ -1,9 +1,9 @@
-package org.merideum.core.api.executor
+package org.merideum.core.api
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
-import org.merideum.core.api.executor.testutils.TestResource
+import org.merideum.core.api.testutils.TestResource
 import org.merideum.core.interpreter.ResourceResolver
 
 class MerideumResourceResolverTests: DescribeSpec({

--- a/core/api/src/test/kotlin/org/merideum/core/api/RequestTests.kt
+++ b/core/api/src/test/kotlin/org/merideum/core/api/RequestTests.kt
@@ -1,9 +1,9 @@
-package org.merideum.core.api.executor
+package org.merideum.core.api
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import org.merideum.core.interpreter.ScriptContext
-import org.merideum.core.api.executor.error.RequestFailException
+import org.merideum.core.api.error.RequestFailException
 
 class RequestTests: DescribeSpec({
   val variable = Request(mapOf())

--- a/core/api/src/test/kotlin/org/merideum/core/api/testutils/TestResource.kt
+++ b/core/api/src/test/kotlin/org/merideum/core/api/testutils/TestResource.kt
@@ -1,4 +1,4 @@
-package org.merideum.core.api.executor.testutils
+package org.merideum.core.api.testutils
 
 import org.merideum.core.interpreter.ScriptContext
 import org.merideum.core.interpreter.Resource

--- a/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/FunctionNotFoundException.kt
+++ b/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/FunctionNotFoundException.kt
@@ -1,3 +1,3 @@
 package org.merideum.core.interpreter.error
 
-class FunctionNotFoundException(functionName: String): RuntimeException("Could not call function with name $functionName")
+class FunctionNotFoundException(functionName: String): ScriptRuntimeException("Could not call function with name $functionName")

--- a/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/FunctionNotFoundException.kt
+++ b/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/FunctionNotFoundException.kt
@@ -1,3 +1,3 @@
 package org.merideum.core.interpreter.error
 
-class FunctionNotFoundException(functionName: String): ScriptRuntimeException("Could not call function with name $functionName")
+class FunctionNotFoundException(functionName: String): ScriptRuntimeException("Could not call function with name $functionName", RuntimeErrorType.FUNCTION)

--- a/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/IdentifierAlreadyDeclaredException.kt
+++ b/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/IdentifierAlreadyDeclaredException.kt
@@ -1,3 +1,3 @@
 package org.merideum.core.interpreter.error
 
-class IdentifierAlreadyDeclaredException(identifier: String): ScriptRuntimeException("The identifier '$identifier' has already been declared.")
+class IdentifierAlreadyDeclaredException(identifier: String): ScriptRuntimeException("The identifier '$identifier' has already been declared.", RuntimeErrorType.IDENTIFIER)

--- a/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/IdentifierAlreadyDeclaredException.kt
+++ b/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/IdentifierAlreadyDeclaredException.kt
@@ -1,3 +1,3 @@
 package org.merideum.core.interpreter.error
 
-class IdentifierAlreadyDeclaredException(identifier: String): RuntimeException("The identifier '$identifier' has already been declared.")
+class IdentifierAlreadyDeclaredException(identifier: String): ScriptRuntimeException("The identifier '$identifier' has already been declared.")

--- a/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/ResourceResolutionException.kt
+++ b/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/ResourceResolutionException.kt
@@ -1,3 +1,3 @@
 package org.merideum.core.interpreter.error
 
-class ResourceResolutionException(resourceName: String): ScriptRuntimeException("Could not resolve resource: $resourceName")
+class ResourceResolutionException(resourceName: String): ScriptRuntimeException("Could not resolve resource: $resourceName", RuntimeErrorType.RESOURCE)

--- a/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/ResourceResolutionException.kt
+++ b/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/ResourceResolutionException.kt
@@ -1,3 +1,3 @@
 package org.merideum.core.interpreter.error
 
-class ResourceResolutionException(resourceName: String): RuntimeException("Could not resolve resource: $resourceName")
+class ResourceResolutionException(resourceName: String): ScriptRuntimeException("Could not resolve resource: $resourceName")

--- a/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/RuntimeErrorType.kt
+++ b/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/RuntimeErrorType.kt
@@ -1,0 +1,8 @@
+package org.merideum.core.interpreter.error
+
+enum class RuntimeErrorType {
+  FUNCTION,
+  TYPE_MISMATCH,
+  IDENTIFIER,
+  RESOURCE
+}

--- a/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/ScriptRuntimeException.kt
+++ b/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/ScriptRuntimeException.kt
@@ -1,0 +1,3 @@
+package org.merideum.core.interpreter.error
+
+open class ScriptRuntimeException(override val message: String): RuntimeException()

--- a/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/ScriptRuntimeException.kt
+++ b/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/ScriptRuntimeException.kt
@@ -1,3 +1,3 @@
 package org.merideum.core.interpreter.error
 
-open class ScriptRuntimeException(override val message: String): RuntimeException()
+open class ScriptRuntimeException(override val message: String, val type: RuntimeErrorType): RuntimeException()

--- a/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/ScriptSyntaxException.kt
+++ b/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/ScriptSyntaxException.kt
@@ -1,0 +1,3 @@
+package org.merideum.core.interpreter.error
+
+open class ScriptSyntaxException(override val message: String): RuntimeException()

--- a/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/TypeMismatchedException.kt
+++ b/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/TypeMismatchedException.kt
@@ -5,4 +5,4 @@ import org.merideum.core.interpreter.type.Type
 class TypeMismatchedException(
   val type: Type,
   val otherType: Type
-): RuntimeException("Cannot perform operation between types '${type.typeName()}' and '${otherType.typeName()}'")
+): ScriptRuntimeException("Cannot perform operation between types '${type.typeName()}' and '${otherType.typeName()}'")

--- a/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/TypeMismatchedException.kt
+++ b/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/TypeMismatchedException.kt
@@ -3,6 +3,6 @@ package org.merideum.core.interpreter.error
 import org.merideum.core.interpreter.type.Type
 
 class TypeMismatchedException(
-  val type: Type,
+  val firstType: Type,
   val otherType: Type
-): ScriptRuntimeException("Cannot perform operation between types '${type.typeName()}' and '${otherType.typeName()}'")
+): ScriptRuntimeException("Cannot perform operation between types '${firstType.typeName()}' and '${otherType.typeName()}'", RuntimeErrorType.TYPE_MISMATCH)

--- a/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/UnknownVariableIdentifierException.kt
+++ b/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/UnknownVariableIdentifierException.kt
@@ -1,3 +1,3 @@
 package org.merideum.core.interpreter.error
 
-class UnknownVariableIdentifierException(identifier: String): RuntimeException("A variable with the identifier '$identifier' does not exist or cannot be accessed.")
+class UnknownVariableIdentifierException(identifier: String): ScriptRuntimeException("A variable with the identifier '$identifier' does not exist or cannot be accessed.")

--- a/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/UnknownVariableIdentifierException.kt
+++ b/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/error/UnknownVariableIdentifierException.kt
@@ -1,3 +1,3 @@
 package org.merideum.core.interpreter.error
 
-class UnknownVariableIdentifierException(identifier: String): ScriptRuntimeException("A variable with the identifier '$identifier' does not exist or cannot be accessed.")
+class UnknownVariableIdentifierException(identifier: String): ScriptRuntimeException("A variable with the identifier '$identifier' does not exist or cannot be accessed.", RuntimeErrorType.IDENTIFIER)

--- a/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/execution/ScriptExecutionResult.kt
+++ b/core/interpreter/src/main/kotlin/org/merideum/core/interpreter/execution/ScriptExecutionResult.kt
@@ -1,8 +1,0 @@
-package org.merideum.core.interpreter.execution
-
-/**
- * The result of a Merideum script run.
- */
-data class ScriptExecutionResult(
-  val output: Map<String, Any?>?
-)

--- a/core/interpreter/src/test/kotlin/org/merideum/core/interpreter/utils/Utils.kt
+++ b/core/interpreter/src/test/kotlin/org/merideum/core/interpreter/utils/Utils.kt
@@ -4,7 +4,6 @@ import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
 import org.merideum.antlr.MerideumLexer
 import org.merideum.antlr.MerideumParser
-import org.merideum.core.interpreter.execution.ScriptExecutionResult
 import org.merideum.core.interpreter.Resource
 import org.merideum.core.interpreter.ResourceResolver
 import org.merideum.core.interpreter.ReturnTermination
@@ -24,7 +23,7 @@ fun executeCode(
       return null
     }
   }
-): ScriptExecutionResult {
+): Map<String, Any?>? {
   val lexer = MerideumLexer(CharStreams.fromString(code))
   val parser = MerideumParser(CommonTokenStream(lexer))
 
@@ -42,5 +41,5 @@ fun executeCode(
     rt.value
   }
 
-  return ScriptExecutionResult(returnValue)
+  return returnValue
 }

--- a/core/interpreter/src/test/kotlin/org/merideum/core/interpreter/visitors/BuiltinTypeTests.kt
+++ b/core/interpreter/src/test/kotlin/org/merideum/core/interpreter/visitors/BuiltinTypeTests.kt
@@ -411,7 +411,7 @@ class BuiltinTypeTests: DescribeSpec({
           executeCode(code, variableScope)
         }
 
-        exception.type shouldBe Type.STRING
+        exception.firstType shouldBe Type.STRING
         exception.otherType shouldBe Type.INT
 
         exception.message shouldBe "Cannot perform operation between types 'string' and 'int'"
@@ -917,7 +917,7 @@ class BuiltinTypeTests: DescribeSpec({
             executeCode(code, variableScope)
           }
 
-          exception.type shouldBe Type.STRING
+          exception.firstType shouldBe Type.STRING
           exception.otherType shouldBe Type.INT
 
           exception.message shouldBe "Cannot perform operation between types 'string' and 'int'"
@@ -937,7 +937,7 @@ class BuiltinTypeTests: DescribeSpec({
             executeCode(code, variableScope)
           }
 
-          exception.type shouldBe Type.STRING
+          exception.firstType shouldBe Type.STRING
           exception.otherType shouldBe Type.INT
 
           exception.message shouldBe "Cannot perform operation between types 'string' and 'int'"
@@ -960,7 +960,7 @@ class BuiltinTypeTests: DescribeSpec({
             executeCode(code, variableScope)
           }
 
-          exception.type shouldBe Type.STRING
+          exception.firstType shouldBe Type.STRING
           exception.otherType shouldBe Type.INT
 
           exception.message shouldBe "Cannot perform operation between types 'string' and 'int'"

--- a/core/interpreter/src/test/kotlin/org/merideum/core/interpreter/visitors/FunctionCallVisitorTests.kt
+++ b/core/interpreter/src/test/kotlin/org/merideum/core/interpreter/visitors/FunctionCallVisitorTests.kt
@@ -25,7 +25,6 @@ class FunctionCallVisitorTests: DescribeSpec({
       val variableScope = VariableScope(null, mutableMapOf())
 
       val actualOutput = executeCode(code, variableScope)
-        .output
         .shouldNotBeNull()
 
       actualOutput["minimum"] shouldBe 300

--- a/core/interpreter/src/test/kotlin/org/merideum/core/interpreter/visitors/ScriptVisitorTests.kt
+++ b/core/interpreter/src/test/kotlin/org/merideum/core/interpreter/visitors/ScriptVisitorTests.kt
@@ -41,7 +41,6 @@ class ScriptVisitorTests: DescribeSpec({
       """.trimMargin()
 
         executeCode(code)
-          .output
           .shouldBeNull()
       }
     }
@@ -56,7 +55,6 @@ class ScriptVisitorTests: DescribeSpec({
       """.trimMargin()
 
         val output = executeCode(code)
-          .output
           .shouldNotBeNull()
 
         output.apply {
@@ -84,7 +82,6 @@ class ScriptVisitorTests: DescribeSpec({
       it("should have output value set to variable name") {
 
         val output = executeCode(code)
-          .output
           .shouldNotBeNull()
 
         output.apply {
@@ -319,7 +316,6 @@ class ScriptVisitorTests: DescribeSpec({
             variableScope,
             resourceResolver = resourceResolver
           )
-            .output
             .shouldNotBeNull()
 
           output["value"] shouldBe "Hello Merideum!"

--- a/examples/basic-ktor-server/src/main/kotlin/org/merideum/examples/ktor/server/Application.kt
+++ b/examples/basic-ktor-server/src/main/kotlin/org/merideum/examples/ktor/server/Application.kt
@@ -1,4 +1,4 @@
-package org.merideum.ktor.server
+package org.merideum.examples.ktor.server
 
 import io.ktor.server.cio.EngineMain
 

--- a/examples/basic-ktor-server/src/main/kotlin/org/merideum/examples/ktor/server/resources/PersonSerializer.kt
+++ b/examples/basic-ktor-server/src/main/kotlin/org/merideum/examples/ktor/server/resources/PersonSerializer.kt
@@ -1,6 +1,6 @@
 package org.merideum.examples.ktor.server.resources
 
-import org.merideum.core.api.executor.serializer.ObjectSerializer
+import org.merideum.core.api.serializer.ObjectSerializer
 import org.merideum.core.interpreter.type.MerideumObject
 import org.merideum.core.interpreter.type.buildObject
 

--- a/ktor/server/src/main/kotlin/org/merideum/ktor/server/ResponseBodySerializer.kt
+++ b/ktor/server/src/main/kotlin/org/merideum/ktor/server/ResponseBodySerializer.kt
@@ -10,17 +10,19 @@ import kotlinx.serialization.json.JsonPrimitive
  * Kotlin Serialization does not support serialization of Any.
  * If the user chooses Kotlin Serialization (which we recommend) we have to manually build the JSON object from the output.
  */
-class OutputSerializer {
+class ResponseBodySerializer {
 
   /**
    * Transforms a Kotlin [Map] into a [JsonObject].
    */
-  fun deserialize(output: Map<String, Any?>?): JsonElement = jsonElement(output)
+  fun deserialize(output: Map<String, Any?>?) = if (output == null) null else jsonElement(output)
 
   /**
    * Recursively transforms a Kotlin type to a [JsonElement]
    */
   private fun jsonElement(value: Any?): JsonElement {
+    if (value == null) return JsonNull
+
     return when (value) {
       is List<*> -> mapJsonArray(value)
 

--- a/ktor/server/src/main/kotlin/org/merideum/ktor/server/ResponseBodySerializer.kt
+++ b/ktor/server/src/main/kotlin/org/merideum/ktor/server/ResponseBodySerializer.kt
@@ -15,7 +15,7 @@ class ResponseBodySerializer {
   /**
    * Transforms a Kotlin [Map] into a [JsonObject].
    */
-  fun deserialize(output: Map<String, Any?>?) = if (output == null) null else jsonElement(output)
+  fun deserialize(body: Map<String, Any?>?) = if (body == null) null else jsonElement(body)
 
   /**
    * Recursively transforms a Kotlin type to a [JsonElement]

--- a/ktor/server/src/main/kotlin/org/merideum/ktor/server/SerializableResponseBody.kt
+++ b/ktor/server/src/main/kotlin/org/merideum/ktor/server/SerializableResponseBody.kt
@@ -1,8 +1,19 @@
 package org.merideum.ktor.server
 
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 
-@kotlinx.serialization.Serializable
-data class SerializableResponseBody(
-  val output: JsonElement
-)
+/**
+ * If there are no errors, then do not show the 'errors' object. If there are errors, then do not show the 'output' object.
+ */
+@Serializable
+open class SerializableResponseBodyWithOutput(
+  val output: JsonElement?
+): SerializableResponseBody
+
+@Serializable
+class SerializableResponseBodyWithErrors(
+  val errors: JsonElement
+): SerializableResponseBody
+
+interface SerializableResponseBody

--- a/ktor/server/src/main/kotlin/org/merideum/ktor/server/plugin/FunctionParser.kt
+++ b/ktor/server/src/main/kotlin/org/merideum/ktor/server/plugin/FunctionParser.kt
@@ -1,7 +1,7 @@
 package org.merideum.ktor.server.plugin
 
-import org.merideum.core.interpreter.type.Type
 import org.merideum.core.api.serializer.ObjectSerializer
+import org.merideum.core.interpreter.type.Type
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.KVisibility
@@ -42,6 +42,7 @@ class FunctionParser(val serializers: Map<String, ObjectSerializer<*>>) {
     }
   }
 
+  // TODO add error checking to make sure a serializer exists for the object.
   private fun getType(type: String): FunctionType {
     return if (type == kotlinString) {
       FunctionType(Type.STRING, "String", null)

--- a/ktor/server/src/main/kotlin/org/merideum/ktor/server/plugin/FunctionParser.kt
+++ b/ktor/server/src/main/kotlin/org/merideum/ktor/server/plugin/FunctionParser.kt
@@ -1,7 +1,7 @@
 package org.merideum.ktor.server.plugin
 
 import org.merideum.core.interpreter.type.Type
-import org.merideum.core.api.executor.serializer.ObjectSerializer
+import org.merideum.core.api.serializer.ObjectSerializer
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.KVisibility

--- a/ktor/server/src/main/kotlin/org/merideum/ktor/server/resource/InternalResource.kt
+++ b/ktor/server/src/main/kotlin/org/merideum/ktor/server/resource/InternalResource.kt
@@ -1,4 +1,4 @@
-package org.merideum.ktor.server.executor
+package org.merideum.ktor.server.resource
 
 import org.merideum.core.interpreter.ScriptContext
 import org.merideum.core.interpreter.Resource
@@ -6,7 +6,7 @@ import org.merideum.core.interpreter.type.ObjectValue
 import org.merideum.core.interpreter.type.Type
 import org.merideum.core.interpreter.type.TypedValue
 import org.merideum.core.interpreter.type.list.ObjectListValue
-import org.merideum.core.api.executor.serializer.ObjectSerializer
+import org.merideum.core.api.serializer.ObjectSerializer
 import org.merideum.ktor.server.plugin.ResourceFunction
 
 @Suppress("UNCHECKED_CAST")

--- a/ktor/server/src/test/kotlin/org/merideum/ktor/server/plugin/FunctionParserTests.kt
+++ b/ktor/server/src/test/kotlin/org/merideum/ktor/server/plugin/FunctionParserTests.kt
@@ -2,7 +2,7 @@ package org.merideum.ktor.server.plugin
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import org.merideum.core.api.executor.serializer.ObjectSerializer
+import org.merideum.core.api.serializer.ObjectSerializer
 import org.merideum.core.interpreter.type.MerideumObject
 import org.merideum.core.interpreter.type.Type
 import kotlin.reflect.KParameter

--- a/ktor/server/src/test/kotlin/org/merideum/ktor/server/plugin/MerideumPluginTests.kt
+++ b/ktor/server/src/test/kotlin/org/merideum/ktor/server/plugin/MerideumPluginTests.kt
@@ -20,8 +20,8 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientCon
 
 @kotlinx.serialization.Serializable
 class ResponseBody(
-  val output: JsonObject?,
-  val errors: JsonObject?
+  val output: JsonObject? = null,
+  val errors: JsonObject? = null
 )
 
 class MerideumPluginTests: DescribeSpec({

--- a/ktor/server/src/test/kotlin/org/merideum/ktor/server/plugin/MerideumPluginTests.kt
+++ b/ktor/server/src/test/kotlin/org/merideum/ktor/server/plugin/MerideumPluginTests.kt
@@ -2,6 +2,7 @@ package org.merideum.ktor.server.plugin
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.maps.shouldNotBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.ktor.client.call.body
@@ -14,11 +15,13 @@ import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.testing.testApplication
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
 
 @kotlinx.serialization.Serializable
 class ResponseBody(
-  val output: JsonObject
+  val output: JsonObject?,
+  val errors: JsonObject?
 )
 
 class MerideumPluginTests: DescribeSpec({
@@ -47,10 +50,54 @@ class MerideumPluginTests: DescribeSpec({
           setBody(code)
         }.body<ResponseBody>()
 
-        response.output.shouldNotBeEmpty()
-        response.output["test"].shouldNotBeNull()
-          .toString()
-          .toInt() shouldBe 123
+        response.output
+          .shouldNotBeNull()
+          .also {
+            it.shouldNotBeEmpty()
+
+            it["test"].shouldNotBeNull()
+              .toString()
+              .toInt() shouldBe 123
+          }
+
+        response.errors.shouldBeNull()
+      }
+    }
+  }
+
+  describe("errors") {
+    it("should include runtime error") {
+      val code = """
+        |request myRequest {
+        |  import asdf: ThrowsError
+        |  
+        |  const test = 123
+        |
+        |  return test
+        |}
+      """.trimMargin()
+
+      testApplication {
+        application {
+          module()
+        }
+
+        val client = createClient {
+          this.install(ClientContentNegotiation) {
+            json()
+          }
+        }
+
+        val response = client.post("/merideum") {
+          setBody(code)
+        }.body<ResponseBody>()
+
+        response.output.shouldBeNull()
+        response.errors
+          .shouldNotBeNull()["runtime"]
+          .shouldNotBeNull()
+          .jsonPrimitive.content shouldBe "Could not resolve resource: ThrowsError"
+
       }
     }
   }

--- a/ktor/server/src/test/kotlin/org/merideum/ktor/server/plugin/MerideumPluginTests.kt
+++ b/ktor/server/src/test/kotlin/org/merideum/ktor/server/plugin/MerideumPluginTests.kt
@@ -15,6 +15,8 @@ import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.testing.testApplication
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
 
@@ -96,8 +98,15 @@ class MerideumPluginTests: DescribeSpec({
         response.errors
           .shouldNotBeNull()["runtime"]
           .shouldNotBeNull()
-          .jsonPrimitive.content shouldBe "Could not resolve resource: ThrowsError"
+          .jsonObject.also {
+            it["type"]
+              .shouldNotBeNull()
+              .jsonPrimitive.contentOrNull shouldBe "RESOURCE"
 
+            it["message"]
+              .shouldNotBeNull()
+              .jsonPrimitive.content shouldBe "Could not resolve resource: ThrowsError"
+          }
       }
     }
   }

--- a/ktor/server/src/test/kotlin/org/merideum/ktor/server/resource/InternalResourceTests.kt
+++ b/ktor/server/src/test/kotlin/org/merideum/ktor/server/resource/InternalResourceTests.kt
@@ -3,13 +3,13 @@ package org.merideum.ktor.server.resource
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import org.merideum.core.api.serializer.ObjectSerializer
-import org.merideum.ktor.server.plugin.FunctionParser
 import org.merideum.core.interpreter.ScriptContext
 import org.merideum.core.interpreter.type.IntValue
 import org.merideum.core.interpreter.type.MerideumObject
 import org.merideum.core.interpreter.type.ObjectValue
 import org.merideum.core.interpreter.type.StringValue
 import org.merideum.core.interpreter.type.buildObject
+import org.merideum.ktor.server.plugin.FunctionParser
 
 class InternalResourceTests: DescribeSpec({
   val instance = HelloWorldService()
@@ -18,7 +18,7 @@ class InternalResourceTests: DescribeSpec({
     "test",
     "org.merideum",
     instance,
-    FunctionParser(mapOf("org.merideum.ktor.server.executor.Person" to PersonSerializer(), "org.merideum.ktor.server.executor.Greeting" to GreetingSerializer())).functionsForInstance(instance)
+    FunctionParser(mapOf("org.merideum.ktor.server.resource.Person" to PersonSerializer(), "org.merideum.ktor.server.resource.Greeting" to GreetingSerializer())).functionsForInstance(instance)
   )
 
   val context = ScriptContext()

--- a/ktor/server/src/test/kotlin/org/merideum/ktor/server/resource/InternalResourceTests.kt
+++ b/ktor/server/src/test/kotlin/org/merideum/ktor/server/resource/InternalResourceTests.kt
@@ -1,8 +1,8 @@
-package org.merideum.ktor.server.executor
+package org.merideum.ktor.server.resource
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import org.merideum.core.api.executor.serializer.ObjectSerializer
+import org.merideum.core.api.serializer.ObjectSerializer
 import org.merideum.ktor.server.plugin.FunctionParser
 import org.merideum.core.interpreter.ScriptContext
 import org.merideum.core.interpreter.type.IntValue


### PR DESCRIPTION
This PR adds basic error handling and adds the concept of `runtime` errors. That is, errors that are generated when a script is running, but are not due to syntax issues.

`errors` is another map on the response body:

```json
{
    "output": {}
    "errors": {}
}
```

If there are no errors, then the `errors` map is left off of the body. If there are errors, than the `output` map is left off the body.

There are three types of errors.
* `syntax`: the code does not follow the Merideum syntax. Presented as a map of runtime error type enum and a helpful string message.
* `runtime`: an error that occurred that was not due to the syntax. Presented as a map of runtime error type enum and a helpful string message.
* `request`: errors created by users, either in the request code, or from a resource. Presented as a map.

At present, there can only be one runtime or syntax error at a time. There can also only be one error type at a time.